### PR TITLE
Fix datetime.utcnow usage

### DIFF
--- a/cogent/base/model/init.py
+++ b/cogent/base/model/init.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-from sqlalchemy.orm import mapperlib
-
 from .deployment import Deployment
 from .house import House
 from .location import Location
@@ -95,11 +93,11 @@ def newClsFromJSON(jsonItem):
     theClass = findClass(theType)
     log.debug("Returned Class {0}".format(theClass))
     # Iterate through to find the class
-    # Create a new instace of this models
+    # Create a new instance of this model
     theModel = theClass()
     log.debug("New model is {0}".format(theModel))
     # And update using the JSON stuff
-    theModel.fromJSON(jsonItem)
+    theModel.from_json(jsonItem)
     log.debug("Updated Model {0}".format(theModel))
     return theModel
 
@@ -137,5 +135,5 @@ def clsFromJSON(theList):
         theModel = typeMap[theType.lower()]()
         # print theModel
 
-        theModel.fromJSON(item)
+        theModel.from_json(item)
         yield theModel

--- a/cogent/base/model/meta.py
+++ b/cogent/base/model/meta.py
@@ -6,6 +6,7 @@ models, That saves the poor things getting confused with scope.
 import json
 import logging
 import warnings
+from zoneinfo import ZoneInfo
 
 import dateutil.parser
 import sqlalchemy
@@ -107,10 +108,10 @@ class SerialiseMixin(object):
              toDict() will be removed in favor of the dict() method, (prepare for transistion to restAlchmey)
         """
 
-        LOG.warning("toDict Depricated, please use dict() function instead")
+        LOG.warning("toDict Deprecated, please use dict() function instead")
         # Appending a table to the dictionary could help us when unpacking objects
         warnings.warn(
-            "meta.toDict() method has been depricated, please use meta.dict() instead",
+            "meta.toDict() method has been deprecated, please use meta.dict() instead",
             DeprecationWarning,
         )
 
@@ -156,7 +157,12 @@ class SerialiseMixin(object):
             else:
                 # Convert if it is a datetime object
                 if isinstance(col.type, sqlalchemy.DateTime) and value:
-                    value = dateutil.parser.parse(value, ignoretz=True)
+                    value = dateutil.parser.parse(value)
+                    if value.tzinfo is None:
+                        # If the timezone is not set, assume UTC
+                        value = value.replace(tzinfo=ZoneInfo("UTC"))
+                    else:
+                        value = value.astimezone(ZoneInfo("UTC"))
                 # And set our variable
             setattr(self, col.name, value)
 
@@ -170,7 +176,7 @@ class SerialiseMixin(object):
         """
 
         warnings.warn(
-            "meta.fromJSON() method has been depricated, please use meta.from_json() instead",
+            "meta.fromJSON() method has been deprecated, please use meta.from_json() instead",
             DeprecationWarning,
         )
 

--- a/cogent/base/model/pushstatus.py
+++ b/cogent/base/model/pushstatus.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from zoneinfo import ZoneInfo
 
 import dateutil
 import sqlalchemy
@@ -52,7 +53,13 @@ class PushStatus(meta.Base, meta.InnoDBMix):
             else:
                 # Convert if it is a datetime object
                 if isinstance(col.type, sqlalchemy.DateTime) and value:
-                    value = dateutil.parser.parse(value, ignoretz=True)
+                    value = dateutil.parser.parse(value)
+                    if value.tzinfo is None:
+                        # If the timezone is not set, assume UTC
+                        value = value.replace(tzinfo=ZoneInfo("UTC"))
+                    else:
+                        value = value.astimezone(ZoneInfo("UTC"))
+
                 # And set our variable
             setattr(self, col.name, value)
 

--- a/cogent/base/model/reading.py
+++ b/cogent/base/model/reading.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import time
+from zoneinfo import ZoneInfo
 
 import dateutil
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer
@@ -173,7 +174,7 @@ class Reading(meta.Base, meta.InnoDBMix):
         Reading table does some trickery with reading.typeId remapping it to
         (type) then we need to take account of that.
 
-        Overloads the default :models.meta.Serializemixin.toDict(): method to
+        Overloads the default :models.meta.Serializemixin.dict(): method to
         take acount of the remapped reading.typeId
 
         .. note::  As this is intended to simplify conversion to and from JSON,
@@ -227,6 +228,10 @@ class Reading(meta.Base, meta.InnoDBMix):
                 # Convert if it is a datetime object
                 if isinstance(col.type, DateTime) and newValue:
                     newValue = dateutil.parser.parse(newValue)
+                    if newValue.tzinfo is None:
+                        newValue = newValue.replace(tzinfo=ZoneInfo("UTC"))
+                    else:
+                        newValue = newValue.astimezone(ZoneInfo("UTC"))
 
                 # And set our variable
 

--- a/cogent/plogg/ploggDatagather.py
+++ b/cogent/plogg/ploggDatagather.py
@@ -11,16 +11,18 @@
 import logging
 import sys
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import reduce
 from optparse import OptionGroup, OptionParser
 
-import cogent.base.model as models
-import cogent.base.model.meta as meta
 import serial
 import serial.tools.list_ports as list_ports
+
 # Do The Database Magic
 import sqlalchemy
+
+import cogent.base.model as models
+import cogent.base.model.meta as meta
 from cogent.base.model import init_data
 
 DB_STRING = "mysql://chuser@localhost/localCh"
@@ -298,7 +300,7 @@ class PloggCollector(object):
             # Get Consumption
             # RMS Current
             # System Uptime
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(UTC)
             watts = float(int(str(ha[7] + ha[8] + ha[9] + ha[10]), 16)) / 1000
             kwhCon = float(int(str(ha[15] + ha[16] + ha[17] + ha[18]), 16)) / 10000
             rmsc = float(int(str(ha[27] + ha[28] + ha[29] + ha[30]), 16)) / 1000

--- a/cogent/report/automated_report.py
+++ b/cogent/report/automated_report.py
@@ -33,7 +33,7 @@ Base = meta.Base
 class OwlsReporter(object):
     """Main reporter class to generate and render automated reports"""
 
-    def __init__(self, enginestr, reportdate=datetime.datetime.utcnow()):
+    def __init__(self, enginestr, reportdate=datetime.datetime.now(datetime.UTC)):
         """Initialise the reporter
         :param enginestr:  SQLA String to connect to database
         :param reportdate: Date to run report for
@@ -430,7 +430,7 @@ if __name__ == "__main__":  # pragma: no cover
         "-d",
         "--date",
         help="Optional date to run report for <DD>-<MM>-<YYYY>",
-        default=datetime.datetime.utcnow(),
+        default=datetime.datetime.now(datetime.UTC),
         required=False,
     )
 

--- a/cogent/report/ccyield.py
+++ b/cogent/report/ccyield.py
@@ -9,8 +9,8 @@ from cogent.base.model import House, LastReport, Location, Node, Reading, Room
 def ccYield(
     session,
     missed_thresh=10,
-    end_t=datetime.datetime.utcnow(),
-    start_t=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
+    end_t=datetime.datetime.now(datetime.UTC),
+    start_t=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
 ):
     html = []
 

--- a/cogent/report/fridgeopen.py
+++ b/cogent/report/fridgeopen.py
@@ -1,6 +1,6 @@
 """Fridge should be less than 10 degrees"""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_
 
@@ -10,7 +10,7 @@ THRESHOLD = 10
 
 
 def fridge_open(
-    session, end_t=datetime.utcnow(), start_t=(datetime.utcnow() - timedelta(hours=4))
+    session, end_t=datetime.now(UTC), start_t=(datetime.now(UTC) - timedelta(hours=4))
 ):
     html = []
 

--- a/cogent/report/lowbat.py
+++ b/cogent/report/lowbat.py
@@ -1,8 +1,9 @@
 import datetime
 
+from sqlalchemy import and_, func
+
 # from datetime import datetime, timedelta
 from cogent.base.model import House, LastReport, Location, Node, Reading, Room
-from sqlalchemy import and_, func
 
 
 def nodesInSet(session, node_set):
@@ -28,8 +29,8 @@ def lowBat(
     session,
     bat_thresh=2.6,
     count_thresh=3,
-    end_t=datetime.datetime.utcnow(),
-    start_t=(datetime.datetime.utcnow() - datetime.timedelta(days=1)),
+    end_t=datetime.datetime.now(datetime.UTC),
+    start_t=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
 ):
     html = []
 

--- a/cogent/report/packetyield.py
+++ b/cogent/report/packetyield.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_, func, or_
 
@@ -29,8 +29,8 @@ def table_with_nodes(session, html, node_set):
 def packetYield(
     session,
     missed_thresh=5,
-    end_t=datetime.utcnow(),
-    start_t=(datetime.utcnow() - timedelta(days=1)),
+    end_t=datetime.now(UTC),
+    start_t=(datetime.now(UTC) - timedelta(days=1)),
 ):
     """report on percentage of packets received over packets transmitted."""
     html = []

--- a/cogent/report/pantryhumid.py
+++ b/cogent/report/pantryhumid.py
@@ -5,7 +5,7 @@ Modifications
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_
 
@@ -15,7 +15,7 @@ THRESHOLD = 79
 
 
 def pantry_humid(
-    session, end_t=datetime.utcnow(), start_t=(datetime.utcnow() - timedelta(hours=24))
+    session, end_t=datetime.now(UTC), start_t=(datetime.now(UTC) - timedelta(hours=24))
 ):
     html = []
 

--- a/cogent/report/serverdown.py
+++ b/cogent/report/serverdown.py
@@ -3,7 +3,7 @@
 Assume X to be 4 hours
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_
 
@@ -11,7 +11,7 @@ from cogent.base.model import NodeState
 
 
 def server_down(
-    session, end_t=datetime.utcnow(), start_t=(datetime.utcnow() - timedelta(hours=4))
+    session, end_t=datetime.now(UTC), start_t=(datetime.now(UTC) - timedelta(hours=4))
 ):
     html = []
     node_state = (

--- a/cogent/report/util.py
+++ b/cogent/report/util.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_, func
 from sqlalchemy.orm import aliased
@@ -83,7 +83,7 @@ def predict(sip_tuple, end_time, restrict=timedelta(hours=7)):
 
 
 def estimate_current_value(
-    session, node_id, type_id, delta_id, endts=datetime.utcnow()
+    session, node_id, type_id, delta_id, endts=datetime.now(UTC)
 ):
 
     # get the last hours data

--- a/tests/base.py
+++ b/tests/base.py
@@ -131,10 +131,10 @@ class ModelTestCase(BaseTestCase):
         # convert to dictionary
         # theDict = theObj.toDict()
         theDict = theObj.dict()
-        # print "DICT ",theDict
+        # print(f"{theDict=}")
         # Convert Back
         newObj = models.newClsFromJSON(theDict)
-        # print "NEW: ",newObj
+        # print(f"{newObj.dict()=}")
         self.assertEqual(theObj, newObj)
 
     def testDict(self):

--- a/tests/test_Deployment.py
+++ b/tests/test_Deployment.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 # Global Timestamp
-NOW = datetime.datetime.utcnow()
+NOW = datetime.datetime.now(datetime.UTC)
 
 
 class TestDeployment(base.ModelTestCase):

--- a/tests/test_Deployment.py
+++ b/tests/test_Deployment.py
@@ -105,9 +105,6 @@ class TestDeployment(base.ModelTestCase):
             "endDate": None,
         }
 
-        itemdict = item.toDict()
-        self.assertEqual(basedict, itemdict)
-
         itemdict = item.dict()
         self.assertEqual(basedict, itemdict)
         # item = models.Deployment(id=42,

--- a/tests/test_House.py
+++ b/tests/test_House.py
@@ -6,7 +6,7 @@ import cogent.base.model as models
 
 from . import base
 
-NOW = datetime.datetime.utcnow()
+NOW = datetime.datetime.now(datetime.UTC)
 
 
 class TestHouse(base.ModelTestCase):
@@ -93,7 +93,7 @@ class TestHouse(base.ModelTestCase):
         self.assertReallyNotEqual(item1, item2)
 
         item2.address = item1.address
-        item2.startDate = datetime.datetime.utcnow()
+        item2.startDate = datetime.datetime.now(datetime.UTC)
 
         self.assertNotEqual(item1, item2)
         self.assertReallyNotEqual(item1, item2)
@@ -129,20 +129,20 @@ class TestHouse(base.ModelTestCase):
         self.assertLess(item1, item2)
 
         item2.address = item1.address
-        item2.startDate = datetime.datetime.utcnow()
+        item2.startDate = datetime.datetime.now(datetime.UTC)
         self.assertLess(item1, item2)
 
-        item1.startDate = datetime.datetime.utcnow()
+        item1.startDate = datetime.datetime.now(datetime.UTC)
         self.assertGreater(item1, item2)
 
         # Order on end-date
         item2.address = item1.address
-        item2.endDate = datetime.datetime.utcnow()
+        item2.endDate = datetime.datetime.now(datetime.UTC)
         self.assertLess(item2, item1)
         self.assertGreater(item1, item2)
 
         # Order on start Date
         item2.endDate = item1.endDate
-        item2.startDate = datetime.datetime.utcnow()
+        item2.startDate = datetime.datetime.now(datetime.UTC)
         self.assertLess(item1, item2)
         self.assertGreater(item2, item1)

--- a/tests/test_Reading.py
+++ b/tests/test_Reading.py
@@ -6,7 +6,7 @@ import cogent.base.model as models
 
 from . import base
 
-NOW = datetime.datetime.utcnow()
+NOW = datetime.datetime.now(datetime.UTC)
 
 
 class TestReading(base.ModelTestCase):
@@ -63,7 +63,7 @@ class TestReading(base.ModelTestCase):
 
         self.assertEqual(item1, item2)
 
-        item2.time = datetime.datetime.utcnow()
+        item2.time = datetime.datetime.now(datetime.UTC)
         self.assertReallyNotEqual(item1, item2)
 
         item2.time = item1.time
@@ -88,7 +88,7 @@ class TestReading(base.ModelTestCase):
 
         self.assertEqual(item1, item2)
 
-        item2.time = datetime.datetime.utcnow()
+        item2.time = datetime.datetime.now(datetime.UTC)
         self.assertGreater(item2, item1)
 
     #     item1 = models.Reading(id=1,

--- a/tests/test_Report.py
+++ b/tests/test_Report.py
@@ -1,11 +1,22 @@
 import datetime
 import unittest
 
-from cogent.base.model import (Base, House, Location, Node, NodeState, Reading,
-                               Room, RoomType, Session, init_model)
-from cogent.report import lowBat
 # from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine, text
+
+from cogent.base.model import (
+    Base,
+    House,
+    Location,
+    Node,
+    NodeState,
+    Reading,
+    Room,
+    RoomType,
+    Session,
+    init_model,
+)
+from cogent.report import lowBat
 
 from . import base
 
@@ -100,7 +111,7 @@ def initDb():
         s.add(Node(id=4098, nodeTypeId=1, location=ll))
         s.add(Node(id=4099, nodeTypeId=1, location=ll))
 
-        t = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        t = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)
         for i in range(288):
             ns = NodeState(time=t, nodeId=23, parent=0, localtime=0, seq_num=i)
             s.add(ns)

--- a/tests/test_Schema.py
+++ b/tests/test_Schema.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 # Original Version used this namespace,
 # So I will too.
@@ -73,7 +73,7 @@ class TestNodeType(base.BaseTestCase):
         b[13] = True
 
         r = NodeType(
-            time=datetime.utcnow(),
+            time=datetime.now(UTC),
             id=0,
             name="base",
             seq=1,
@@ -98,7 +98,7 @@ class TestNodeType(base.BaseTestCase):
         b[13] = True
 
         r = NodeType(
-            time=datetime.utcnow(),
+            time=datetime.now(UTC),
             id=0,
             name="base",
             seq=1,
@@ -171,7 +171,7 @@ class TestSchema(base.BaseTestCase):
         dep = Deployment(
             name="TestDep",
             description="Does this work",
-            startDate=datetime.utcnow(),
+            startDate=datetime.now(UTC),
             endDate=None,
         )
         session.add(dep)
@@ -196,7 +196,7 @@ class TestSchema(base.BaseTestCase):
         session.commit()
 
         # Add a house
-        h = House(deploymentId=1, address="1 Sampson", startDate=datetime.utcnow())
+        h = House(deploymentId=1, address="1 Sampson", startDate=datetime.now(UTC))
 
         session.add(h)
         session.commit()
@@ -219,7 +219,7 @@ class TestSchema(base.BaseTestCase):
             houseId=1,
             name="Mr Man",
             contactNumber="01212342345",
-            startDate=datetime.utcnow(),
+            startDate=datetime.now(UTC),
         )
 
         session.add(occ)
@@ -282,7 +282,7 @@ class TestSchema(base.BaseTestCase):
         session.add(st)
         session.commit()
 
-        tt = datetime.utcnow() - timedelta(minutes=(500))
+        tt = datetime.now(UTC) - timedelta(minutes=(500))
 
         for i in range(100):
 

--- a/www/index.py
+++ b/www/index.py
@@ -17,7 +17,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from distutils.version import StrictVersion as V
 
 import gviz_api
@@ -357,7 +357,7 @@ def tree(req, period="day", debug=""):
             req.content_type = _CONTENT_TEXT
             cmd = "cat"
 
-        t = datetime.utcnow() - timedelta(minutes=mins)
+        t = datetime.now(UTC) - timedelta(minutes=mins)
 
         p = Popen(
             cmd, shell=True, bufsize=4096, stdin=PIPE, stdout=PIPE, close_fds=True
@@ -521,7 +521,7 @@ def exportDataForm(err=None):
         s.append(
             'End Date: <input type="text" name="EndDate" '
             'value="'
-            + (datetime.utcnow()).strftime("%d/%m/%Y")
+            + (datetime.now(UTC)).strftime("%d/%m/%Y")
             + '"  onfocus="displayDatePicker(\'EndDate\');"/>'
         )
         s.append("</td><tr></table>")
@@ -673,7 +673,7 @@ def nodeGraph(req, node=None, typ="0", period="day", ago="0", debug="n"):
         )
 
         debug = debug != "n"
-        startts = datetime.utcnow() - timedelta(minutes=(ago_i + 1) * mins)
+        startts = datetime.now(UTC) - timedelta(minutes=(ago_i + 1) * mins)
 
         endts = startts + timedelta(minutes=mins)
 
@@ -785,7 +785,7 @@ def viewLog(req):
 
 def missing():
     try:
-        t = datetime.utcnow() - timedelta(hours=8)
+        t = datetime.now(UTC) - timedelta(hours=8)
         session = Session()
         s = ["<p>"]
 
@@ -904,7 +904,7 @@ def yield24(sort="house"):
             )
         )
 
-        start_t = datetime.utcnow() - timedelta(days=1)
+        start_t = datetime.now(UTC) - timedelta(days=1)
 
         # next get the count per node
         seqcnt_q = (
@@ -1524,7 +1524,7 @@ def lowbat(bat="2.6"):
     # TODO: provide estimates of battery lifetime and sort.
     try:
         batlvl = _float(bat, default=2.6)
-        t = datetime.utcnow() - timedelta(days=1)
+        t = datetime.now(UTC) - timedelta(days=1)
         session = Session()
         html = []
         empty = True
@@ -1803,7 +1803,7 @@ def graph(
 
         debug = debug is not None
         # week = timedelta(minutes=int(_periods["week"]))
-        startts = datetime.utcnow() - timedelta(minutes=minsago_i)
+        startts = datetime.now(UTC) - timedelta(minutes=minsago_i)
         # deltats = (datetime.utcnow() - minsago_i) - week
 
         endts = startts + timedelta(minutes=duration_i)


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow()` with timezone-aware `datetime.now(datetime.UTC)`
- update imports accordingly
- run `ruff --fix` on touched files

## Testing
- `ruff check cogent/plogg/ploggDatagather.py cogent/report/automated_report.py cogent/report/ccyield.py cogent/report/fridgeopen.py cogent/report/lowbat.py cogent/report/packetyield.py cogent/report/pantryhumid.py cogent/report/serverdown.py cogent/report/util.py tests/test_Deployment.py tests/test_House.py tests/test_Reading.py tests/test_Report.py tests/test_Schema.py www/index.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68764f7a994c83278a4633e451e6a643