### PR TITLE
Ensure Dockerfile works with docker-compose v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
-FROM python:3.12-slim
+FROM python:3.11-slim
 WORKDIR /app
 
 # Install build tools and MySQL client libraries
 RUN apt-get update \
-    && apt-get install -y gcc default-libmysqlclient-dev \
+    && apt-get install -y --no-install-recommends \
+        gcc \
+        default-libmysqlclient-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies first to leverage Docker layer caching
+COPY requirements.txt /tmp/
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy application code
 COPY . /app
 
-# Install python dependencies
-RUN pip install --no-cache-dir \
-        Flask==2.2.5 \
-        SQLAlchemy \
-        mysqlclient
 
 # Default database connection
 ENV CH_DBURL mysql://chuser:chpass@db/ch?connect_timeout=1


### PR DESCRIPTION
## Summary
- adjust base image to python:3.11-slim
- install required build packages without recommends
- install dependencies from `requirements.txt` before copying the rest of the code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779bb9b5bc8327a760bd5fee4bc8c0