### PR TITLE
Fix missing package in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy application code
 COPY . /app
+# Install the local cogent package in editable mode so the Flask app
+# can import it.
+RUN pip install --no-cache-dir -e .
 
 
 # Default database connection


### PR DESCRIPTION
## Summary
- install the local `cogent` package when building the Docker image

## Testing
- `pip install -e .` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877aeb5dde083279d4837b03f34ec42