### PR TITLE
Add node location info on graphs

### DIFF
--- a/flaskapp/app.py
+++ b/flaskapp/app.py
@@ -1,7 +1,19 @@
 import os
 
-from cogent.base.model import Node, Session, init_model
-from flask import Flask, render_template
+import json
+from datetime import datetime
+
+from cogent.base.model import (
+    House,
+    Location,
+    Node,
+    Reading,
+    Room,
+    SensorType,
+    Session,
+    init_model,
+)
+from flask import Flask, render_template, request, abort
 from sqlalchemy import create_engine
 
 app = Flask(__name__)
@@ -9,6 +21,34 @@ app = Flask(__name__)
 DBURL = os.environ.get("CH_DBURL", "mysql://chuser@localhost/ch?connect_timeout=1")
 engine = create_engine(DBURL, echo=False, pool_recycle=60)
 init_model(engine)
+
+
+def _to_gviz_json(description, data):
+    """Return Google Visualization JSON data table string."""
+    cols = []
+    for desc in description:
+        col = {"label": desc[0], "type": desc[1]}
+        cols.append(col)
+
+    def _conv(value, typ):
+        if typ == "datetime" and isinstance(value, datetime):
+            return "Date(%d,%d,%d,%d,%d,%d)" % (
+                value.year,
+                value.month - 1,
+                value.day,
+                value.hour,
+                value.minute,
+                value.second,
+            )
+        return value
+
+    rows = []
+    for row in data:
+        cells = []
+        for val, desc in zip(row, description):
+            cells.append({"v": _conv(val, desc[1])})
+        rows.append({"c": cells})
+    return json.dumps({"cols": cols, "rows": rows})
 
 
 @app.route("/")
@@ -24,6 +64,77 @@ def nodes():
     finally:
         session.close()
     return render_template("nodes.html", title="Nodes", nodes=records)
+
+
+@app.route("/graph")
+@app.route("/graph/<int:node_id>")
+@app.route("/graph/<int:node_id>/<int:type_id>")
+def graph(node_id=None, type_id=None):
+    if node_id is None:
+        node_id = request.args.get("node_id")
+    if node_id is None:
+        node_id = os.environ.get("CH_GRAPH_NODE", 23)
+    if type_id is None:
+        type_id = request.args.get("typ")
+    if type_id is None:
+        type_id = os.environ.get("CH_GRAPH_TYPE", 0)
+    try:
+        node_id = int(node_id)
+        type_id = int(type_id)
+    except (TypeError, ValueError):
+        abort(404)
+
+    session = Session()
+    try:
+        records = (
+            session.query(Reading.time, Reading.value)
+            .filter(Reading.nodeId == node_id, Reading.typeId == type_id)
+            .order_by(Reading.time)
+            .limit(50)
+            .all()
+        )
+        sensor = (
+            session.query(SensorType.name, SensorType.units)
+            .filter(SensorType.id == type_id)
+            .one_or_none()
+        )
+        house_room = (
+            session.query(House.address, Room.name)
+            .join(Location, House.id == Location.houseId)
+            .join(Room, Room.id == Location.roomId)
+            .join(Node, Node.locationId == Location.id)
+            .filter(Node.id == node_id)
+            .one_or_none()
+        )
+    finally:
+        session.close()
+
+    house, room = house_room if house_room else ("Unknown", "Unknown")
+
+    data = [(r.time, r.value) for r in records]
+    description = [
+        ("Time", "datetime"),
+        ("Value", "number"),
+    ]
+    json_data = _to_gviz_json(description, data)
+    label = (
+        f"{sensor.name} ({sensor.units})" if sensor else f"Type {type_id}"
+    )
+    page_title = f"Node {node_id} {label}"
+    heading = f"{house}: {room} ({node_id})"
+    options = {
+        "title": label,
+        "legend": {"position": "none"},
+        "hAxis": {"title": "Time"},
+        "vAxis": {"title": label},
+    }
+    return render_template(
+        "graph.html",
+        title=page_title,
+        heading=heading,
+        json_data=json_data,
+        options=options,
+    )
 
 
 if __name__ == "__main__":

--- a/flaskapp/templates/graph.html
+++ b/flaskapp/templates/graph.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block head %}
+    {{ super() }}
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+    <script type="text/javascript">
+      google.load('visualization', '1', {packages:['corechart']});
+      google.setOnLoadCallback(drawChart);
+      function drawChart() {
+        var json_data = new google.visualization.DataTable({{ json_data|safe }}, 0.6);
+        var chart = new google.visualization.LineChart(document.getElementById('chart_div'));
+        var options = {{ options|tojson }};
+        chart.draw(json_data, options);
+      }
+    </script>
+{% endblock %}
+{% block content %}
+<div id="grphtitle">{{ heading }}</div>
+<div id="chart_div" style="width: 900px; height: 500px;"></div>
+{% endblock %}

--- a/flaskapp/templates/nodes.html
+++ b/flaskapp/templates/nodes.html
@@ -2,7 +2,7 @@
 {% block content %}
 <ul>
     {% for node in nodes %}
-        <li>Node {{ node.id }}</li>
+        <li><a href="{{ url_for('graph', node_id=node.id, type_id=0) }}">Node {{ node.id }}</a></li>
     {% else %}
         <li>No nodes found.</li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- include House, Room, and Location models for graph route
- query for a node's house and room when drawing graphs
- display the node's location above the chart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687903ef0414832798f7f868c0823474