### PR TITLE
Refine session get and exception handling in logfromflat

### DIFF
--- a/cogent/base/logfromflat.py
+++ b/cogent/base/logfromflat.py
@@ -90,12 +90,12 @@ class LogFromFlat(object):
         session = meta.Session()
         try:
             models.populateData.init_data(session)
-            if session.query(SensorType).get(0) is None:
+            if session.get(SensorType, 0) is None:
                 raise Exception(
                     "SensorType must be populated by alembic "
                     + "before starting LogFromFlat"
                 )
-        except:
+        except Exception:
             session.rollback()
             raise
         finally:


### PR DESCRIPTION
## Summary
- avoid swallowing errors in `create_tables` by catching `Exception`
- use `session.get(SensorType, 0)` for SQLAlchemy 2.x compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dcb91432083279eee3a2e5eee73bc