### PR TITLE
Add network tree diagram link to navigation

### DIFF
--- a/flaskapp/templates/base.html
+++ b/flaskapp/templates/base.html
@@ -22,6 +22,7 @@
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.missing') }}">Missing</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.yield24') }}">Yield 24h</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('legacy_graph.current_values') }}">Current values</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('tree.tree_page') }}">Network tree</a></li>
             </ul>
         </div>
     </div>

--- a/flaskapp/templates/index.html
+++ b/flaskapp/templates/index.html
@@ -3,4 +3,5 @@
 <p>Welcome to the CogentHouse Maintenance Portal</p>
 <p>This portal can be used to monitor your deployed CogentHouse sensors and to view graphs of all recorded data.</p>
 <p><a href="{{ url_for('main.nodes') }}">List Nodes</a></p>
+<p><a href="{{ url_for('tree.tree_page') }}">Network tree diagram</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add Network tree page to navbar for quick access to tree diagram.
- Link the main index page to the network tree diagram for direct navigation.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad7d0a0c9c8327b6c4d86c92b8e329