### PR TITLE
Switch to ruff and clean up lint warnings

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,19 +30,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest mypy
+        pip install ruff pytest mypy
         git submodule update --init --recursive
         pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff check .
     - name: Type check with mypy
       run: |
-        mypy flaskapp
+        mypy . --exclude www
     - name: Test with pytest
       run: |
         pytest

--- a/cogent/alembic/env.py
+++ b/cogent/alembic/env.py
@@ -1,9 +1,9 @@
 from logging.config import fileConfig
 
-from cogent.base.model import Base
+from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from alembic import context
+from cogent.base.model import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/cogent/alembic/versions/1a04848f8857_remove_id_from_nodestate_new_primary_.py
+++ b/cogent/alembic/versions/1a04848f8857_remove_id_from_nodestate_new_primary_.py
@@ -6,13 +6,13 @@ Create Date: 2014-02-19 12:57:36.472580
 
 """
 
-# revision identifiers, used by Alembic.
-revision = "1a04848f8857"
-down_revision = "2b40fc51f91e"
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "1a04848f8857"
+down_revision = "2b40fc51f91e"
 
 
 def upgrade():

--- a/cogent/alembic/versions/1e6b75bbade9_test.py
+++ b/cogent/alembic/versions/1e6b75bbade9_test.py
@@ -6,13 +6,13 @@ Create Date: 2020-02-18 21:02:08.334697
 
 """
 
-# revision identifiers, used by Alembic.
-revision = "1e6b75bbade9"
-down_revision = "b90c0470e9da"
-
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision = "1e6b75bbade9"
+down_revision = "b90c0470e9da"
 
 
 def upgrade():

--- a/cogent/base/logfromflat.py
+++ b/cogent/base/logfromflat.py
@@ -17,15 +17,15 @@ import json
 import logging
 import math
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+# import time
+from sqlalchemy import and_, create_engine
 
 import cogent.base.model as models
 import cogent.base.model.meta as meta
-# import time
-import sqlalchemy
 from cogent.base.model import Node, NodeState, Reading, SensorType
-from sqlalchemy import and_, create_engine
 
 LOGGER = logging.getLogger("ch.base")
 

--- a/cogent/base/model/__init__.py
+++ b/cogent/base/model/__init__.py
@@ -16,8 +16,7 @@ from .deploymentmetadata import DeploymentMetadata
 from .event import Event
 from .host import Host
 from .house import House
-from .init import (clsFromJSON, findClass, init_model, initialise_sql,
-                   newClsFromJSON)
+from .init import clsFromJSON, findClass, init_model, initialise_sql, newClsFromJSON
 from .lastreport import LastReport
 from .location import Location
 from .meta import Base, Session
@@ -65,6 +64,9 @@ __all__ = [
     SensorType,
     Server,
     Session,
+    Timings,
+    User,
+    Weather,
     clsFromJSON,
     findClass,
     init_data,

--- a/cogent/base/model/deployment.py
+++ b/cogent/base/model/deployment.py
@@ -8,6 +8,7 @@ Table to represent deployments.
 
 # SQL Alchemy Relevant information
 from sqlalchemy import Column, DateTime, Integer, String
+
 # And Backrefs and Relations.
 from sqlalchemy.orm import relationship
 

--- a/cogent/base/model/init.py
+++ b/cogent/base/model/init.py
@@ -2,10 +2,11 @@ import json
 import logging
 
 import cogent.base.model.meta as meta
+
 from .deployment import Deployment
 from .house import House
 from .location import Location
-from .meta import Base, Session
+from .meta import Base
 from .node import Node
 from .nodeboot import NodeBoot
 from .nodestate import NodeState

--- a/cogent/base/model/nodeboot.py
+++ b/cogent/base/model/nodeboot.py
@@ -7,8 +7,7 @@
 
 import logging
 
-from sqlalchemy import (Boolean, Column, DateTime, ForeignKey, Index, Integer,
-                        String)
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String
 
 from . import meta
 

--- a/cogent/scripts/initializedb.py
+++ b/cogent/scripts/initializedb.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 import sqlalchemy
-import transaction
+import transaction  # type: ignore[import-untyped]
 from alembic import command
 from alembic.config import Config
 

--- a/flaskapp/views/legacy_graph.py
+++ b/flaskapp/views/legacy_graph.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 import io
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import matplotlib
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
+import sqlalchemy
 from flask import Blueprint, Response, abort, render_template, request
 from matplotlib.path import Path
 from sqlalchemy import and_, func
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
-import sqlalchemy
 
+import cogent.base.model.meta as meta
 from cogent.base.model import (
     House,
     Location,
@@ -24,7 +25,6 @@ from cogent.base.model import (
     SensorType,
     Session,
 )
-import cogent.base.model.meta as meta
 from cogent.sip.sipsim import PartSplineReconstruct, SipPhenom
 
 from .graph import _to_gviz_json

--- a/flaskapp/views/tree.py
+++ b/flaskapp/views/tree.py
@@ -6,11 +6,10 @@ from sqlalchemy import and_, func
 
 from cogent.base.model import Location, Node, NodeState, Room, Session
 
+from .legacy_graph import _mins, _periods
+
 _CONTENT_SVG = "image/svg+xml"
 _CONTENT_TEXT = "text/plain"
-
-from .legacy_graph import _periods, _mins
-
 
 tree_bp = Blueprint("tree", __name__)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-from setuptools import setup
+from setuptools import setup  # type: ignore[import-untyped]
 
 # Fix for when a virtualenv is used to install
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_Schema.py
+++ b/tests/test_Schema.py
@@ -1,11 +1,25 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from cogent.base.model import (Base, Bitset, Deployment, DeploymentMetadata,
-                               House, Location, Node, NodeState, NodeType,
-                               Occupier, Reading, Room, RoomType, SensorType)
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+from cogent.base.model import (
+    Base,
+    Bitset,
+    Deployment,
+    DeploymentMetadata,
+    House,
+    Location,
+    Node,
+    NodeState,
+    NodeType,
+    Occupier,
+    Reading,
+    Room,
+    RoomType,
+    SensorType,
+)
 
 
 @pytest.fixture

--- a/tests/test_current_values.py
+++ b/tests/test_current_values.py
@@ -2,19 +2,19 @@ from datetime import datetime, timezone
 
 from sqlalchemy import create_engine
 
-from flaskapp import create_app
 from cogent.base.model import (
     Base,
-    Session,
     House,
     Location,
     Node,
     Reading,
     Room,
     SensorType,
+    Session,
     init_data,
     init_model,
 )
+from flaskapp import create_app
 
 
 def test_current_values(monkeypatch, tmp_path):

--- a/tests/test_logfromflat.py
+++ b/tests/test_logfromflat.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
+from sqlalchemy import and_
+
 from cogent.base.logfromflat import LogFromFlat
 from cogent.base.model import (
     Bitset,
@@ -24,7 +26,6 @@ from cogent.base.model import (
     SensorType,
     meta,
 )
-from sqlalchemy import and_
 
 DBURL = "sqlite:///:memory:"
 

--- a/tests/test_lowbat.py
+++ b/tests/test_lowbat.py
@@ -2,18 +2,18 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import create_engine
 
-from flaskapp import create_app
 from cogent.base.model import (
     Base,
-    Session,
     House,
     Location,
     Node,
     Reading,
     Room,
+    Session,
     init_data,
     init_model,
 )
+from flaskapp import create_app
 
 
 def test_lowbat(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- replace flake8 with ruff in CI and run mypy on the whole project while skipping the legacy `www` directory
- tidy various modules by sorting imports and exporting previously unused types
- add type-ignore annotations for modules lacking stubs

## Testing
- `ruff check .`
- `mypy . --exclude www`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d5fef63c8327a7ef976f1efe5843