### PR TITLE
Switch container to gunicorn on port 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN pip install --no-cache-dir -e .
 
 # Default database connection
 ENV CH_DBURL mysql://chuser:chpass@db/ch?connect_timeout=1
+ENV LOGFROMFLAT_DIR=/data/silicon
 
-EXPOSE 5000
-CMD ["python", "-m", "flaskapp.app"]
+EXPOSE 8000
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "flaskapp:app"]


### PR DESCRIPTION
## Summary
- Expose port 8000 and run the Flask app via Gunicorn
- Add LOGFROMFLAT_DIR environment variable for logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32fb0749883279cdabd7ed9b1b752