### PR TITLE
Centralize LastReport flag handling with enum-backed helpers

### DIFF
--- a/cogent/report/lastreport.py
+++ b/cogent/report/lastreport.py
@@ -1,0 +1,34 @@
+from enum import StrEnum
+
+from cogent.base.model import LastReport
+
+
+class LastReportName(StrEnum):
+    FRIDGE_OVER_TEMP = "FridgeOverTemp"
+    PANTRY_HUMIDITY_HIGH = "PantryHumidityHigh"
+
+
+def get_last_report_flag(session, name: LastReportName):
+    report = (
+        session.query(LastReport).filter(LastReport.name == name.value).first()
+    )
+    active = report is not None and report.value == "True"
+    return report, active
+
+
+def set_last_report_flag(
+    session, name: LastReportName, active: bool, report: LastReport | None = None
+):
+    if report is None:
+        report = (
+            session.query(LastReport)
+            .filter(LastReport.name == name.value)
+            .first()
+        )
+    if report is None:
+        report = LastReport(name=name.value, value=str(active))
+        session.add(report)
+    else:
+        report.value = str(active)
+    session.commit()
+    return report

--- a/cogent/report/pantryhumid.py
+++ b/cogent/report/pantryhumid.py
@@ -11,6 +11,12 @@ from sqlalchemy import and_
 
 from cogent.base.model import Location, Node, Reading, Room
 
+from cogent.report.lastreport import (
+    LastReportName,
+    get_last_report_flag,
+    set_last_report_flag,
+)
+
 THRESHOLD = 79
 
 
@@ -18,6 +24,9 @@ def pantry_humid(
     session, end_t=datetime.now(UTC), start_t=(datetime.now(UTC) - timedelta(hours=24))
 ):
     html = []
+    humid_report, humid_active = get_last_report_flag(
+        session, LastReportName.PANTRY_HUMIDITY_HIGH
+    )
 
     pantry_humidity = (
         session.query(Reading.time, Reading.value)
@@ -39,7 +48,24 @@ def pantry_humid(
     if pantry_humidity is not None:
         (qt, qv) = pantry_humidity
         if qv > THRESHOLD:
-            html.append("<p><b>Pantry humidity is {} at {}</b></p>".format(qv, qt))
+            if not humid_active:
+                humid_report = set_last_report_flag(
+                    session,
+                    LastReportName.PANTRY_HUMIDITY_HIGH,
+                    True,
+                    report=humid_report,
+                )
+                html.append(
+                    "<p><b>Pantry humidity is {} at {}</b></p>".format(qv, qt)
+                )
+        elif humid_active:
+            html.append("<p><b>Pantry humidity has recovered</b></p>")
+            set_last_report_flag(
+                session,
+                LastReportName.PANTRY_HUMIDITY_HIGH,
+                False,
+                report=humid_report,
+            )
     else:
         html.append("<p><b>Pantry reading not found</b></p>")
 

--- a/cogent/report/pantryhumid.py
+++ b/cogent/report/pantryhumid.py
@@ -10,7 +10,6 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import and_
 
 from cogent.base.model import Location, Node, Reading, Room
-
 from cogent.report.lastreport import (
     LastReportName,
     get_last_report_flag,


### PR DESCRIPTION
### Motivation

- Two report modules duplicated logic for reading/writing `LastReport` flag entries and used magic string names. 
- The change hides database access details behind a small API to make flag usage consistent and reduce repetition. 
- Using an enumeration prevents scattered "magic" name strings and centralizes valid flag names. 

### Description

- Add `cogent/report/lastreport.py` providing `LastReportName` enum and helper functions `get_last_report_flag` and `set_last_report_flag` for reading and writing flag entries. 
- Update `cogent/report/fridgeopen.py` to use the new helpers and `LastReportName.FRIDGE_OVER_TEMP` instead of direct `LastReport` queries and magic strings. 
- Update `cogent/report/pantryhumid.py` to use the new helpers and `LastReportName.PANTRY_HUMIDITY_HIGH` and to only emit alerts when the flag transitions. 
- Adjust tests to account for the refactor and to continue validating alert suppression and recovery behavior. 

### Testing

- Ran `pytest tests/test_pantry_humid_report.py tests/test_fridgeopen.py` which executed the updated tests. 
- All collected tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961de298b6c8327931a57333ff83602)