### PR TITLE
Add sensor data export page and CSV download endpoint

### DIFF
--- a/cogent/templates/base.html
+++ b/cogent/templates/base.html
@@ -22,6 +22,7 @@
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.yield24') }}">Yield 24h</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.lowbat') }}">Low batteries</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('main.electricity_usage') }}">Electricity usage</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('main.export_page') }}">Export</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('graph.current_values') }}">Current values</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('graph.all_graphs') }}">All graphs</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('tree.tree_page') }}">Network tree</a></li>
@@ -42,4 +43,3 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>
-

--- a/cogent/templates/export.html
+++ b/cogent/templates/export.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block content %}
+<p class="text-muted">
+    Download raw sensor readings in CSV format. Leave filters empty to export all available readings.
+</p>
+
+<form method="get" action="{{ url_for('main.export_download') }}" class="row g-3">
+    <div class="col-md-6">
+        <label for="sensor-types" class="form-label">Sensor types</label>
+        <select id="sensor-types" name="sensor_type" multiple class="form-select" size="10">
+            {% for sensor_type in sensor_types %}
+            <option value="{{ sensor_type.id }}" {% if sensor_type.id in selected_sensor_type_ids %}selected{% endif %}>
+                {{ sensor_type.name }} (ID {{ sensor_type.id }})
+            </option>
+            {% endfor %}
+        </select>
+        <div class="form-text">Hold Ctrl (Windows/Linux) or Command (macOS) to select multiple values.</div>
+    </div>
+
+    <div class="col-md-6">
+        <label for="rooms" class="form-label">Rooms</label>
+        <select id="rooms" name="room" multiple class="form-select" size="10">
+            {% for room in rooms %}
+            <option value="{{ room.id }}" {% if room.id in selected_room_ids %}selected{% endif %}>
+                {{ room.name }} (ID {{ room.id }})
+            </option>
+            {% endfor %}
+        </select>
+        <div class="form-text">You can select multiple rooms.</div>
+    </div>
+
+    <div class="col-md-3">
+        <label for="start-date" class="form-label">Start date</label>
+        <input id="start-date" type="date" name="start_date" class="form-control" value="{{ start_date }}">
+    </div>
+
+    <div class="col-md-3">
+        <label for="end-date" class="form-label">End date</label>
+        <input id="end-date" type="date" name="end_date" class="form-control" value="{{ end_date }}">
+    </div>
+
+    <div class="col-12">
+        <button type="submit" class="btn btn-primary">Download CSV</button>
+    </div>
+</form>
+{% endblock %}

--- a/cogent/views/main.py
+++ b/cogent/views/main.py
@@ -1,6 +1,8 @@
+import csv
+import io
 from datetime import UTC, datetime, time, timedelta
 
-from flask import Blueprint, render_template, request, url_for
+from flask import Blueprint, Response, render_template, request, url_for
 from sqlalchemy import and_, distinct, func
 from sqlalchemy.orm import aliased
 
@@ -27,6 +29,15 @@ _PERIOD_DEFINITIONS = [
     ("2-years", "Last 24 months", 730),
 ]
 _PERIOD_LOOKUP = {key: days for key, _, days in _PERIOD_DEFINITIONS}
+
+
+def _parse_date(value):
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
 
 
 @main_bp.route("/")
@@ -323,6 +334,98 @@ def electricity_usage():
         has_data=has_data,
         start_date=start_date,
         end_date=end_date,
+    )
+
+
+@main_bp.route("/export")
+def export_page():
+    start_date_raw = request.args.get("start_date")
+    end_date_raw = request.args.get("end_date")
+    selected_sensor_type_ids = {
+        int(value)
+        for value in request.args.getlist("sensor_type")
+        if value.isdigit()
+    }
+    selected_room_ids = {
+        int(value) for value in request.args.getlist("room") if value.isdigit()
+    }
+
+    with Session() as session:
+        sensor_types = (
+            session.query(SensorType.id, SensorType.name)
+            .order_by(SensorType.name)
+            .all()
+        )
+        rooms = session.query(Room.id, Room.name).order_by(Room.name).all()
+
+    return render_template(
+        "export.html",
+        title="Export data",
+        sensor_types=sensor_types,
+        rooms=rooms,
+        selected_sensor_type_ids=selected_sensor_type_ids,
+        selected_room_ids=selected_room_ids,
+        start_date=start_date_raw,
+        end_date=end_date_raw,
+    )
+
+
+@main_bp.route("/export/download")
+def export_download():
+    start_date = _parse_date(request.args.get("start_date"))
+    end_date = _parse_date(request.args.get("end_date"))
+
+    sensor_type_ids = [
+        int(value) for value in request.args.getlist("sensor_type") if value.isdigit()
+    ]
+    room_ids = [int(value) for value in request.args.getlist("room") if value.isdigit()]
+
+    query_filters = []
+    if sensor_type_ids:
+        query_filters.append(Reading.typeId.in_(sensor_type_ids))
+    if room_ids:
+        query_filters.append(Room.id.in_(room_ids))
+    if start_date:
+        query_filters.append(Reading.time >= datetime.combine(start_date, time.min))
+    if end_date:
+        query_filters.append(Reading.time <= datetime.combine(end_date, time.max))
+
+    with Session() as session:
+        query = (
+            session.query(
+                Reading.time,
+                Reading.nodeId,
+                Reading.typeId,
+                Reading.locationId,
+                Reading.value,
+            )
+            .join(Location, Reading.locationId == Location.id)
+            .join(Room, Location.roomId == Room.id)
+        )
+        if query_filters:
+            query = query.filter(*query_filters)
+        rows = query.order_by(Reading.time, Reading.nodeId, Reading.typeId).all()
+
+    csv_io = io.StringIO()
+    writer = csv.writer(csv_io)
+    writer.writerow(["time", "nodeId", "typeId", "locationId", "value"])
+    for row in rows:
+        writer.writerow(
+            [
+                row.time.isoformat() if row.time else "",
+                row.nodeId,
+                row.typeId,
+                row.locationId,
+                row.value,
+            ]
+        )
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    filename = f"sensor_export_{timestamp}.csv"
+    return Response(
+        csv_io.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import create_engine
+
+from cogent import create_app
+from cogent.base.model import (
+    Base,
+    House,
+    Location,
+    Node,
+    Reading,
+    Room,
+    SensorType,
+    Session,
+    init_data,
+    init_model,
+)
+
+
+def test_export_page_and_download(monkeypatch, tmp_path):
+    db_path = tmp_path / "test.db"
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+    init_model(engine)
+    Base.metadata.create_all(engine)
+    init_data()
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    later = now + timedelta(days=1)
+
+    with Session(engine) as session:
+        house = House(id=100, address="House 1")
+        room1 = Room(id=100, name="Kitchen")
+        room2 = Room(id=101, name="Bedroom")
+        loc1 = Location(id=100, houseId=house.id, roomId=room1.id)
+        loc2 = Location(id=101, houseId=house.id, roomId=room2.id)
+        node1 = Node(id=100, locationId=loc1.id)
+        node2 = Node(id=101, locationId=loc2.id)
+        session.add_all([house, room1, room2, loc1, loc2, node1, node2])
+        session.commit()
+
+        for st_id in (0, 1):
+            st = session.get(SensorType, st_id)
+            st.active = True
+        session.commit()
+
+        session.add_all(
+            [
+                Reading(time=now, nodeId=node1.id, typeId=0, locationId=loc1.id, value=10.0),
+                Reading(time=later, nodeId=node2.id, typeId=1, locationId=loc2.id, value=99.0),
+            ]
+        )
+        session.commit()
+
+    monkeypatch.setenv("CH_DBURL", db_url)
+    app = create_app()
+    client = app.test_client()
+
+    page = client.get("/export")
+    assert page.status_code == 200
+    assert b"Download CSV" in page.data
+    assert b"Sensor types" in page.data
+    assert b"Rooms" in page.data
+
+    day = now.date().isoformat()
+    response = client.get(
+        f"/export/download?sensor_type=0&room=100&start_date={day}&end_date={day}"
+    )
+    assert response.status_code == 200
+    assert response.headers["Content-Type"].startswith("text/csv")
+    assert "attachment; filename=" in response.headers["Content-Disposition"]
+
+    body = response.data.decode("utf-8")
+    assert "time,nodeId,typeId,locationId,value" in body
+    assert f"{now.replace(tzinfo=None).isoformat()},100,0,100,10.0" in body
+    assert "99.0" not in body


### PR DESCRIPTION
### Motivation
- Provide a simple way to download raw, unprocessed sensor readings from the database with selectable filters for sensor types, rooms, and date range so users can export data for external analysis.

### Description
- Added an `Export` menu item in `cogent/templates/base.html` that links to the new export workflow.
- Added `cogent/templates/export.html` which provides multi-select controls for sensor types and rooms and date pickers for start/end dates, posting to `/export/download`.
- Implemented `export_page` and `export_download` routes in `cogent/views/main.py`; `export_download` queries the `Reading` table (joined via `Location`/`Room`), applies the requested filters, and returns a CSV of raw columns `time,nodeId,typeId,locationId,value`.
- Added `tests/test_export.py` which seeds a temporary SQLite DB, verifies the export page renders, and asserts the filtered CSV download contains expected raw rows.

### Testing
- Ran `pytest -q tests/test_export.py tests/test_current_values.py` and the suite passed (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5279f6bc8327bf3d7fbacd4d0879)