### PR TITLE
Refactor low battery report to align with fridge report patterns

### DIFF
--- a/cogent/report/lowbat.py
+++ b/cogent/report/lowbat.py
@@ -1,12 +1,27 @@
-import datetime
+from ast import literal_eval
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import and_, func
 
-# from datetime import datetime, timedelta
 from cogent.base.model import House, LastReport, Location, Node, Reading, Room
 
+LOW_BAT_REPORT_NAME = "low-bat-nodes"
+BATTERY_TYPE_ID = 6
 
-def nodesInSet(session, node_set):
+
+def _parse_node_set(value: str) -> set[int]:
+    try:
+        parsed = literal_eval(value)
+    except (ValueError, SyntaxError):
+        return set()
+
+    if not isinstance(parsed, set):
+        return set()
+
+    return {int(node_id) for node_id in parsed}
+
+
+def nodes_in_set(session, node_set):
     html = []
     html.append('<table border="1">')
     html.append("<tr><th>Node</th><th>House</th><th>Room</th></tr>")
@@ -29,26 +44,31 @@ def lowBat(
     session,
     bat_thresh=2.6,
     count_thresh=3,
-    end_t=datetime.datetime.now(datetime.UTC),
-    start_t=(datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=1)),
+    end_t=None,
+    start_t=None,
 ):
+    if end_t is None:
+        end_t = datetime.now(UTC)
+    if start_t is None:
+        start_t = end_t - timedelta(days=1)
+
     html = []
 
     last_lowbat = (
-        session.query(LastReport).filter(LastReport.name == "low-bat-nodes").first()
+        session.query(LastReport)
+        .filter(LastReport.name == LOW_BAT_REPORT_NAME)
+        .first()
     )
-    if last_lowbat is not None:
-        last_lowbat_set = eval(last_lowbat.value)
-        # set([int(x) for x in last_lowbat.value.split(',')])
-    else:
-        last_lowbat_set = set()
+    last_lowbat_set = (
+        _parse_node_set(last_lowbat.value) if last_lowbat is not None else set()
+    )
 
     lowbat_set = set()
     for n, c in (
         session.query(Reading.nodeId, func.count(Reading.nodeId).label("count"))
         .filter(
             and_(
-                Reading.typeId == 6,
+                Reading.typeId == BATTERY_TYPE_ID,
                 Reading.time >= start_t,
                 Reading.time < end_t,
                 Reading.value < bat_thresh,
@@ -66,19 +86,21 @@ def lowBat(
 
         if len(gone_low) > 0:
             html.append("<h3>Nodes that have started to report low battery</h3>")
-            html.extend(nodesInSet(session, gone_low))
+            html.extend(nodes_in_set(session, gone_low))
 
         if len(gone_high) > 0:
             html.append("<h3>Nodes no longer reporting low battery</h3>")
-            html.extend(nodesInSet(session, gone_high))
-
-        #        s = ','.join([str(a) for a in lowbat_set])
+            html.extend(nodes_in_set(session, gone_high))
 
         if last_lowbat is None:
-            last_lowbat = LastReport(name="low-bat-nodes", value=repr(lowbat_set))
+            last_lowbat = LastReport(name=LOW_BAT_REPORT_NAME, value=repr(lowbat_set))
             session.add(last_lowbat)
         else:
             last_lowbat.value = repr(lowbat_set)
         session.commit()
 
     return html
+
+
+def nodesInSet(session, node_set):  # noqa: N802
+    return nodes_in_set(session, node_set)


### PR DESCRIPTION
### Motivation
- Bring `lowbat` report implementation in line with newer report modules like `fridgeopen.py` for consistency and safer behavior.
- Remove unsafe parsing and improve clarity around time defaults and report constants.

### Description
- Replaced global timestamp defaults with `None` sentinels and initialize UTC-aware `end_t`/`start_t` inside `lowBat` using `datetime.now(UTC)` and `timedelta`.
- Replaced `eval`-based parsing of persisted node sets with a safe `_parse_node_set` implemented via `ast.literal_eval` and type validation.
- Introduced constants `LOW_BAT_REPORT_NAME` and `BATTERY_TYPE_ID` and updated queries to use them.
- Added a snake_case helper `nodes_in_set` and preserved the legacy `nodesInSet` wrapper for backward compatibility.

### Testing
- Ran `pytest -q tests/test_lowbat.py tests/test_Report.py::TestReport::test_lowbat` and the run succeeded with `2 passed in 3.30s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60edc05f883279fa5326b7abed953)